### PR TITLE
[block] if menu block admin is set to true, we want an error if not available

### DIFF
--- a/src/DependencyInjection/Factory/BlockAdminFactory.php
+++ b/src/DependencyInjection/Factory/BlockAdminFactory.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Cmf\Bundle\SonataPhpcrAdminIntegrationBundle\DependencyInjection\Factory;
 
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -70,10 +71,10 @@ class BlockAdminFactory implements AdminFactoryInterface
 
         $bundles = $container->getParameter('kernel.bundles');
 
-        if (true === $config['enable_menu']
-            || ('auto' === $config['enable_menu'] && isset($bundles['CmfMenuBundle']))
-        ) {
+        if ($config['enable_menu'] && array_key_exists('CmfMenuBundle', $bundles)) {
             $loader->load('block-menu.xml');
+        } elseif (true === $config['enable_menu'] && !array_key_exists('CmfMenuBundle', $bundles)) {
+            throw new InvalidConfigurationException('To use the menu block, you need the symfony-cmf/menu-bundle in your project.');
         }
     }
 }

--- a/src/DependencyInjection/Factory/BlockAdminFactory.php
+++ b/src/DependencyInjection/Factory/BlockAdminFactory.php
@@ -21,6 +21,8 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
  */
 class BlockAdminFactory implements AdminFactoryInterface
 {
+    use IsConfigEnabledTrait;
+
     /**
      * {@inheritdoc}
      */
@@ -71,7 +73,9 @@ class BlockAdminFactory implements AdminFactoryInterface
 
         $bundles = $container->getParameter('kernel.bundles');
 
-        if ($config['enable_menu'] && array_key_exists('CmfMenuBundle', $bundles)) {
+        if ($this->isConfigEnabled($container, $config, 'enable_menu')
+            && array_key_exists('CmfMenuBundle', $bundles)
+        ) {
             $loader->load('block-menu.xml');
         } elseif (true === $config['enable_menu'] && !array_key_exists('CmfMenuBundle', $bundles)) {
             throw new InvalidConfigurationException('To use the menu block, you need the symfony-cmf/menu-bundle in your project.');

--- a/src/DependencyInjection/Factory/IsConfigEnabledTrait.php
+++ b/src/DependencyInjection/Factory/IsConfigEnabledTrait.php
@@ -15,12 +15,19 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 trait IsConfigEnabledTrait
 {
-    public function isConfigEnabled(ContainerBuilder $container, array $config)
+    /**
+     * @param ContainerBuilder $container   The container
+     * @param array            $config      The configuration section that could be enabled
+     * @param string           $enabledFlag Name of the flag that tells if config is enabled. Defaults to "enabled"
+     *
+     * @return bool
+     */
+    public function isConfigEnabled(ContainerBuilder $container, array $config, $enabledFlag = 'enabled')
     {
-        if (!array_key_exists('enabled', $config)) {
+        if (!array_key_exists($enabledFlag, $config)) {
             throw new InvalidArgumentException("The config array has no 'enabled' key.");
         }
 
-        return (bool) $container->getParameterBag()->resolveValue($config['enabled']);
+        return (bool) $container->getParameterBag()->resolveValue($config[$enabledFlag]);
     }
 }


### PR DESCRIPTION
without this change, there is no difference between `true` and `auto`. the semantics is that auto does silently not load the service, while true complains if it can't load.