### PR TITLE
Also support sub classes in admin descriptor

### DIFF
--- a/src/Description/SonataEnhancer.php
+++ b/src/Description/SonataEnhancer.php
@@ -39,6 +39,8 @@ class SonataEnhancer implements DescriptionEnhancerInterface
      */
     private $urlGenerator;
 
+    private $adminMap = [];
+
     /**
      * @param Pool                  $pool
      * @param UrlGeneratorInterface $urlGenerator
@@ -58,7 +60,7 @@ class SonataEnhancer implements DescriptionEnhancerInterface
 
         // sonata has dependency on ClassUtils so this is fine.
         $class = ClassUtils::getClass($object);
-        $admin = $this->pool->getAdminByClass($class);
+        $admin = $this->getAdminByClass($class);
 
         $links = [];
 
@@ -118,6 +120,22 @@ class SonataEnhancer implements DescriptionEnhancerInterface
         // sonata has dependency on ClassUtils so this is fine.
         $class = ClassUtils::getClass($payload);
 
-        return $this->pool->hasAdminByClass($class);
+        return null !== $this->getAdminByClass($class);
+    }
+
+    private function getAdminByClass($class)
+    {
+        if (array_key_exists($class, $this->adminMap)) {
+            return $this->adminMap[$class];
+        }
+
+        $_class = $class;
+        while ($_class && !$this->pool->hasAdminByClass($_class)) {
+            $_class = get_parent_class($_class);
+        }
+
+        $this->adminMap[$class] = $_class ? $this->pool->getAdminByClass($_class) : null;
+
+        return $this->adminMap[$class];
     }
 }

--- a/tests/Unit/Description/SonataEnhancerTest.php
+++ b/tests/Unit/Description/SonataEnhancerTest.php
@@ -40,6 +40,7 @@ class SonataEnhancerTest extends \PHPUnit_Framework_TestCAse
         $this->pool = new Pool($this->container, 'Test', 'logo');
         $this->pool->setAdminClasses([
             'stdClass' => ['std_class_admin'],
+            'Exception' => ['std_class_admin'],
         ]);
         $this->pool->setAdminServiceIds(['std_class_admin']);
 
@@ -58,11 +59,11 @@ class SonataEnhancerTest extends \PHPUnit_Framework_TestCAse
     }
 
     /**
-     * It should provide a description.
+     * @dataProvider provideDescriptionData
      */
-    public function testDescriptionProvide()
+    public function testDescriptionProvide($class)
     {
-        $this->resource->getPayload()->willReturn(new \stdClass());
+        $this->resource->getPayload()->willReturn($class);
 
         $this->generator->generate(Argument::cetera())->will(function ($args) {
             return '/'.$args[0];
@@ -76,6 +77,14 @@ class SonataEnhancerTest extends \PHPUnit_Framework_TestCAse
         $this->assertEquals('/std_class_create', $description->get(Descriptor::LINK_CREATE_HTML));
         $this->assertEquals('/std_class_show', $description->get(Descriptor::LINK_SHOW_HTML));
         $this->assertEquals('/std_class_delete', $description->get(Descriptor::LINK_REMOVE_HTML));
+    }
+
+    public function provideDescriptionData()
+    {
+        return [
+            [new \stdClass()],
+            [new \LogicException()],
+        ];
     }
 }
 


### PR DESCRIPTION
This allows content objects (e.g. the `DemoContent` in the sandbox) to have admin descriptors.