### PR TITLE
fix the integration for routing admin with content bundle

### DIFF
--- a/src/Admin/Routing/RouteAdmin.php
+++ b/src/Admin/Routing/RouteAdmin.php
@@ -64,7 +64,7 @@ class RouteAdmin extends AbstractAdmin
                         ->add(
                             'content',
                             TreeSelectType::class,
-                            ['root_node' => $this->routeRoot, 'widget' => 'browser', 'required' => false]
+                            ['root_node' => $this->contentRoot, 'widget' => 'browser', 'required' => false]
                         )
                     ->end() // group general
                 ->end() // tab general

--- a/src/DependencyInjection/CmfSonataPhpcrAdminIntegrationExtension.php
+++ b/src/DependencyInjection/CmfSonataPhpcrAdminIntegrationExtension.php
@@ -47,9 +47,7 @@ class CmfSonataPhpcrAdminIntegrationExtension extends Extension implements Compi
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $this->addDefaultFactories($container);
-
-        $configuration = new Configuration($this->factories);
+        $configuration = $this->getConfiguration([], $container);
         $config = $this->processConfiguration($configuration, $configs);
         $bundles = $container->getParameter('kernel.bundles');
 
@@ -63,6 +61,18 @@ class CmfSonataPhpcrAdminIntegrationExtension extends Extension implements Compi
 
         $loader->load('main.xml');
         $loader->load('enhancer.xml');
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Overwritten because configuration can not be auto instantiated as it has a constructor.
+     */
+    public function getConfiguration(array $config, ContainerBuilder $container)
+    {
+        $this->addDefaultFactories($container);
+
+        return new Configuration($this->factories);
     }
 
     private function loadBundles(array $config, XmlFileLoader $loader, ContainerBuilder $container)

--- a/src/DependencyInjection/Factory/RoutingAdminFactory.php
+++ b/src/DependencyInjection/Factory/RoutingAdminFactory.php
@@ -35,6 +35,7 @@ class RoutingAdminFactory implements AdminFactoryInterface, CompilerPassInterfac
     public function addConfiguration(NodeBuilder $builder)
     {
         $builder->scalarNode('basepath')->defaultNull()->end();
+        $builder->scalarNode('content_basepath')->defaultNull()->end();
     }
 
     /**
@@ -45,6 +46,7 @@ class RoutingAdminFactory implements AdminFactoryInterface, CompilerPassInterfac
         $loader->load('routing.xml');
 
         $container->setParameter('cmf_sonata_phpcr_admin_integration.routing.basepath', $config['basepath']);
+        $container->setParameter('cmf_sonata_phpcr_admin_integration.routing.content_basepath', $config['content_basepath']);
     }
 
     /**
@@ -57,11 +59,17 @@ class RoutingAdminFactory implements AdminFactoryInterface, CompilerPassInterfac
         }
 
         $basepath = $container->getParameter('cmf_sonata_phpcr_admin_integration.routing.basepath');
-        if (null !== $basepath) {
-            return;
+        if (null === $basepath) {
+            $basepaths = $container->getParameter('cmf_routing.dynamic.persistence.phpcr.route_basepaths');
+            $container->setParameter('cmf_sonata_phpcr_admin_integration.routing.basepath', reset($basepaths));
         }
 
-        $basepaths = $container->getParameter('cmf_routing.dynamic.persistence.phpcr.route_basepaths');
-        $container->setParameter('cmf_sonata_phpcr_admin_integration.routing.basepath', reset($basepaths));
+        $contentBasepath = $container->getParameter('cmf_sonata_phpcr_admin_integration.routing.content_basepath');
+        if (null === $contentBasepath) {
+            $contentBasepath = $container->hasParameter('cmf_content.persistence.phpcr.content_basepath')
+                ? $container->getParameter('cmf_content.persistence.phpcr.content_basepath')
+                : '/';
+            $container->setParameter('cmf_sonata_phpcr_admin_integration.routing.content_basepath', $contentBasepath);
+        }
     }
 }

--- a/src/Resources/config/routing.xml
+++ b/src/Resources/config/routing.xml
@@ -25,7 +25,7 @@
             </call>
 
             <call method="setContentRoot">
-                <argument>%cmf_routing.dynamic.persistence.phpcr.content_basepath%</argument>
+                <argument>%cmf_sonata_phpcr_admin_integration.routing.content_basepath%</argument>
             </call>
 
             <call method="setRouteRoot">


### PR DESCRIPTION
i realized that the content basepath is still configured on the routing bundle, but not used at all. then i realized we did not properly handle content base path here in the admin. this should fix all of that