### PR TITLE
add missing translation for frontend link extension

### DIFF
--- a/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.cs.xliff
+++ b/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.cs.xliff
@@ -606,6 +606,16 @@
                 <target>Delete</target>
             </trans-unit>
 
+            <!-- TODO translate -->
+            <trans-unit id="admin.menu_frontend_link_caption">
+                <source>admin.menu_frontend_link_caption</source>
+                <target>Frontend</target>
+            </trans-unit>
+            <trans-unit id="admin.menu_frontend_link_title">
+                <source>admin.menu_frontend_link_title</source>
+                <target>Open frontend view in new tab</target>
+            </trans-unit>
+
 
             <!-- $Seo -->
             <trans-unit id="form.tab_seo">

--- a/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.de.xliff
+++ b/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.de.xliff
@@ -586,6 +586,14 @@
                 <target>Löschen</target>
             </trans-unit>
 
+            <trans-unit id="admin.menu_frontend_link_caption">
+                <source>admin.menu_frontend_link_caption</source>
+                <target>Frontend</target>
+            </trans-unit>
+            <trans-unit id="admin.menu_frontend_link_title">
+                <source>admin.menu_frontend_link_title</source>
+                <target>Frontend Ansicht in neuem Tab öffnen</target>
+            </trans-unit>
 
             <!-- $Seo -->
             <trans-unit id="form.tab_seo">

--- a/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.en.xliff
+++ b/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.en.xliff
@@ -581,6 +581,14 @@
                 <target>Delete</target>
             </trans-unit>
 
+            <trans-unit id="admin.menu_frontend_link_caption">
+                <source>admin.menu_frontend_link_caption</source>
+                <target>Frontend</target>
+            </trans-unit>
+            <trans-unit id="admin.menu_frontend_link_title">
+                <source>admin.menu_frontend_link_title</source>
+                <target>Open frontend view in new tab</target>
+            </trans-unit>
 
             <!-- $Seo -->
             <trans-unit id="form.tab_seo">

--- a/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.es.xliff
+++ b/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.es.xliff
@@ -581,6 +581,16 @@
                 <target>Borrar</target>
             </trans-unit>
 
+            <!-- TODO translate -->
+            <trans-unit id="admin.menu_frontend_link_caption">
+                <source>admin.menu_frontend_link_caption</source>
+                <target>Frontend</target>
+            </trans-unit>
+            <trans-unit id="admin.menu_frontend_link_title">
+                <source>admin.menu_frontend_link_title</source>
+                <target>Open frontend view in new tab</target>
+            </trans-unit>
+
 
             <!-- $Seo -->
             <trans-unit id="form.tab_seo">

--- a/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.fr.xliff
+++ b/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.fr.xliff
@@ -355,7 +355,7 @@
                 <target>Éléments</target>
             </trans-unit>
             <trans-unit id="form.group_target">
-                <source>form.group_target</source>                
+                <source>form.group_target</source>
                 <target>Destination du lien</target>
             </trans-unit>
             <trans-unit id="form.group_menu_options">
@@ -376,7 +376,7 @@
                 <target>Type de lien</target>
             </trans-unit>
             <trans-unit id="form.label_link">
-                <source>form.label_link</source>                
+                <source>form.label_link</source>
                 <target>Lien</target>
             </trans-unit>
             <trans-unit id="form.label_route">
@@ -484,7 +484,7 @@
                 <target>Emplacement</target>
             </trans-unit>
             <trans-unit id="form.group_path">
-                <source>form.group_path</source>                
+                <source>form.group_path</source>
                 <target>Chemin</target>
             </trans-unit>
             <trans-unit id="form.group_data">
@@ -579,6 +579,15 @@
             <trans-unit id="breadcrumb.link_redirect_route_delete">
                 <source>breadcrumb.link_redirect_route_delete</source>
                 <target>Supprimer</target>
+            </trans-unit>
+
+            <trans-unit id="admin.menu_frontend_link_caption">
+                <source>admin.menu_frontend_link_caption</source>
+                <target>Frontend</target>
+            </trans-unit>
+            <trans-unit id="admin.menu_frontend_link_title">
+                <source>admin.menu_frontend_link_title</source>
+                <target>Aperçu dans la page</target>
             </trans-unit>
 
 

--- a/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.it.xliff
+++ b/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.it.xliff
@@ -581,6 +581,16 @@
                 <target>Elimina</target>
             </trans-unit>
 
+            <!-- TODO translate -->
+            <trans-unit id="admin.menu_frontend_link_caption">
+                <source>admin.menu_frontend_link_caption</source>
+                <target>Frontend</target>
+            </trans-unit>
+            <trans-unit id="admin.menu_frontend_link_title">
+                <source>admin.menu_frontend_link_title</source>
+                <target>Open frontend view in new tab</target>
+            </trans-unit>
+
 
             <!-- $Seo -->
             <trans-unit id="form.tab_seo">

--- a/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.nl.xliff
+++ b/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.nl.xliff
@@ -581,6 +581,16 @@
                 <target>Verwijderen</target>
             </trans-unit>
 
+            <!-- TODO translate -->
+            <trans-unit id="admin.menu_frontend_link_caption">
+                <source>admin.menu_frontend_link_caption</source>
+                <target>Frontend</target>
+            </trans-unit>
+            <trans-unit id="admin.menu_frontend_link_title">
+                <source>admin.menu_frontend_link_title</source>
+                <target>Open frontend view in new tab</target>
+            </trans-unit>
+
 
             <!-- $Seo -->
             <trans-unit id="form.tab_seo">

--- a/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.pl.xliff
+++ b/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.pl.xliff
@@ -679,6 +679,16 @@
                 <target>Usuń</target>
             </trans-unit>
 
+            <!-- TODO translate -->
+            <trans-unit id="admin.menu_frontend_link_caption">
+                <source>admin.menu_frontend_link_caption</source>
+                <target>Frontend</target>
+            </trans-unit>
+            <trans-unit id="admin.menu_frontend_link_title">
+                <source>admin.menu_frontend_link_title</source>
+                <target>Open frontend view in new tab</target>
+            </trans-unit>
+
 
             <!-- $Seo -->
             <trans-unit id="form.tab_seo">

--- a/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.pt_BR.xliff
+++ b/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.pt_BR.xliff
@@ -582,6 +582,16 @@
                 <target>Excluir</target>
             </trans-unit>
 
+            <!-- TODO translate -->
+            <trans-unit id="admin.menu_frontend_link_caption">
+                <source>admin.menu_frontend_link_caption</source>
+                <target>Frontend</target>
+            </trans-unit>
+            <trans-unit id="admin.menu_frontend_link_title">
+                <source>admin.menu_frontend_link_title</source>
+                <target>Open frontend view in new tab</target>
+            </trans-unit>
+
 
             <!-- $Seo -->
             <trans-unit id="form.tab_seo">

--- a/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.sk.xliff
+++ b/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.sk.xliff
@@ -607,6 +607,16 @@
                 <target>Delete</target>
             </trans-unit>
 
+            <!-- TODO translate -->
+            <trans-unit id="admin.menu_frontend_link_caption">
+                <source>admin.menu_frontend_link_caption</source>
+                <target>Frontend</target>
+            </trans-unit>
+            <trans-unit id="admin.menu_frontend_link_title">
+                <source>admin.menu_frontend_link_title</source>
+                <target>Open frontend view in new tab</target>
+            </trans-unit>
+
 
             <!-- $Seo -->
             <trans-unit id="form.tab_seo">

--- a/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.sl.xliff
+++ b/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.sl.xliff
@@ -581,6 +581,16 @@
                 <target>Izbriši</target>
             </trans-unit>
 
+            <!-- TODO translate -->
+            <trans-unit id="admin.menu_frontend_link_caption">
+                <source>admin.menu_frontend_link_caption</source>
+                <target>Frontend</target>
+            </trans-unit>
+            <trans-unit id="admin.menu_frontend_link_title">
+                <source>admin.menu_frontend_link_title</source>
+                <target>Open frontend view in new tab</target>
+            </trans-unit>
+
 
             <!-- $Seo -->
             <trans-unit id="form.tab_seo">


### PR DESCRIPTION
i only add them to english here. found that routing bundle 1.4 branch only has it for english. is that ok or do we have to copy that to every translation with a todo comment?