### PR TITLE
Allign form tab group

### DIFF
--- a/src/Admin/Routing/Extension/RouteReferrersExtension.php
+++ b/src/Admin/Routing/Extension/RouteReferrersExtension.php
@@ -26,7 +26,7 @@ class RouteReferrersExtension extends AbstractAdminExtension
     private $formGroup;
     private $formTab;
 
-    public function __construct($formGroup = 'form.group_routes', $formTab = 'form.tab_routing')
+    public function __construct($formGroup = 'form.group_routing', $formTab = 'form.tab_routing')
     {
         $this->formGroup = $formGroup;
         $this->formTab = $formTab;
@@ -40,7 +40,7 @@ class RouteReferrersExtension extends AbstractAdminExtension
 
         $formMapper
             ->tab($this->formTab)
-                ->with('form.group_routes', ['translation_domain' => 'CmfSonataPhpcrAdminIntegrationBundle'])
+                ->with($this->formGroup, ['translation_domain' => 'CmfSonataPhpcrAdminIntegrationBundle'])
                     ->add(
                         'routes',
                         CollectionType::class,

--- a/src/DependencyInjection/Factory/CoreAdminFactory.php
+++ b/src/DependencyInjection/Factory/CoreAdminFactory.php
@@ -63,8 +63,8 @@ class CoreAdminFactory implements AdminFactoryInterface
         $loader->load('core.xml');
 
         foreach ($config['extensions'] as $extension => $values) {
-            $container->setParameter('cmf_sonata_phpcr_admin_integration.core.'.$extension.'.form_group', $values['form_group']);
-            $container->setParameter('cmf_sonata_phpcr_admin_integration.core.'.$extension.'.form_tab', $values['form_tab']);
+            $container->setParameter('cmf_sonata_phpcr_admin_integration.core.extension.'.$extension.'.form_group', $values['form_group']);
+            $container->setParameter('cmf_sonata_phpcr_admin_integration.core.extension.'.$extension.'.form_tab', $values['form_tab']);
         }
     }
 }

--- a/src/DependencyInjection/Factory/MenuAdminFactory.php
+++ b/src/DependencyInjection/Factory/MenuAdminFactory.php
@@ -12,6 +12,7 @@
 namespace Symfony\Cmf\Bundle\SonataPhpcrAdminIntegrationBundle\DependencyInjection\Factory;
 
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 

--- a/src/DependencyInjection/Factory/RoutingAdminFactory.php
+++ b/src/DependencyInjection/Factory/RoutingAdminFactory.php
@@ -34,8 +34,21 @@ class RoutingAdminFactory implements AdminFactoryInterface, CompilerPassInterfac
      */
     public function addConfiguration(NodeBuilder $builder)
     {
-        $builder->scalarNode('basepath')->defaultNull()->end();
-        $builder->scalarNode('content_basepath')->defaultNull()->end();
+        $builder
+            ->arrayNode('extensions')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->arrayNode('referrers')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('form_group')->defaultValue('form.group_routing')->end()
+                        ->scalarNode('form_tab')->defaultValue('form.tab_routing')->end()
+                    ->end()
+                    ->end()
+                ->end()
+            ->end()
+            ->scalarNode('basepath')->defaultNull()->end()
+            ->scalarNode('content_basepath')->defaultNull()->end();
     }
 
     /**
@@ -47,6 +60,14 @@ class RoutingAdminFactory implements AdminFactoryInterface, CompilerPassInterfac
 
         $container->setParameter('cmf_sonata_phpcr_admin_integration.routing.basepath', $config['basepath']);
         $container->setParameter('cmf_sonata_phpcr_admin_integration.routing.content_basepath', $config['content_basepath']);
+        $container->setParameter(
+            'cmf_sonata_phpcr_admin_integration.routing.extension.referrers.from_group',
+            $config['extensions']['referrers']['form_group']
+        );
+        $container->setParameter(
+            'cmf_sonata_phpcr_admin_integration.routing.extension.referrers.from_tab',
+            $config['extensions']['referrers']['form_tab']
+        );
     }
 
     /**

--- a/src/DependencyInjection/Factory/SeoAdminFactory.php
+++ b/src/DependencyInjection/Factory/SeoAdminFactory.php
@@ -34,8 +34,18 @@ class SeoAdminFactory implements AdminFactoryInterface
     public function addConfiguration(NodeBuilder $builder)
     {
         $builder
-            ->scalarNode('form_group')->defaultValue('form.group_seo')->end()
-            ->scalarNode('form_tab')->defaultValue('form.tab_seo')->end()
+            ->arrayNode('extensions')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->arrayNode('metadata')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('form_group')->defaultValue('form.group_seo')->end()
+                        ->scalarNode('form_tab')->defaultValue('form.tab_seo')->end()
+                    ->end()
+                ->end()
+                ->end()
+            ->end()
         ;
     }
 
@@ -45,7 +55,7 @@ class SeoAdminFactory implements AdminFactoryInterface
     public function create(array $config, ContainerBuilder $container, XmlFileLoader $loader)
     {
         $loader->load('seo.xml');
-        $container->setParameter('cmf_sonata_phpcr_admin_integration.seo.form_group', $config['form_group']);
-        $container->setParameter('cmf_sonata_phpcr_admin_integration.seo.form_tab', $config['form_tab']);
+        $container->setParameter('cmf_sonata_phpcr_admin_integration.seo.extension.metadata.form_group', $config['extensions']['metadata']['form_group']);
+        $container->setParameter('cmf_sonata_phpcr_admin_integration.seo.extension.metadata.form_tab', $config['extensions']['metadata']['form_tab']);
     }
 }

--- a/src/Resources/config/core.xml
+++ b/src/Resources/config/core.xml
@@ -17,8 +17,8 @@
                 id="cmf_sonata_phpcr_admin_integration.core.extension.publish_workflow.publishable"
                 class="Symfony\Cmf\Bundle\SonataPhpcrAdminIntegrationBundle\Admin\Core\Extension\PublishableExtension"
                 public="false">
-            <argument>%cmf_sonata_phpcr_admin_integration.core.publishable.form_group%</argument>
-            <argument>%cmf_sonata_phpcr_admin_integration.core.publishable.form_tab%</argument>
+            <argument>%cmf_sonata_phpcr_admin_integration.core.extension.publishable.form_group%</argument>
+            <argument>%cmf_sonata_phpcr_admin_integration.core.extension.publishable.form_tab%</argument>
             <tag name="sonata.admin.extension"/>
         </service>
 
@@ -26,8 +26,8 @@
                 id="cmf_sonata_phpcr_admin_integration.core.extension.publish_workflow.time_period"
                 class="Symfony\Cmf\Bundle\SonataPhpcrAdminIntegrationBundle\Admin\Core\Extension\PublishTimePeriodExtension"
                 public="false">
-            <argument>%cmf_sonata_phpcr_admin_integration.core.publish_time.form_group%</argument>
-            <argument>%cmf_sonata_phpcr_admin_integration.core.publish_time.form_tab%</argument>
+            <argument>%cmf_sonata_phpcr_admin_integration.core.extension.publish_time.form_group%</argument>
+            <argument>%cmf_sonata_phpcr_admin_integration.core.extension.publish_time.form_tab%</argument>
             <tag name="sonata.admin.extension"/>
         </service>
 

--- a/src/Resources/config/routing.xml
+++ b/src/Resources/config/routing.xml
@@ -60,6 +60,8 @@
         <service
                 id="cmf_sonata_phpcr_admin_integration.routing.extension.route_referrers"
                 class="Symfony\Cmf\Bundle\SonataPhpcrAdminIntegrationBundle\Admin\Routing\Extension\RouteReferrersExtension">
+            <argument>%cmf_sonata_phpcr_admin_integration.routing.extension.referrers.from_group%</argument>
+            <argument>%cmf_sonata_phpcr_admin_integration.routing.extension.referrers.from_tab%</argument>
             <tag name="sonata.admin.extension"/>
         </service>
 

--- a/src/Resources/config/seo.xml
+++ b/src/Resources/config/seo.xml
@@ -8,8 +8,8 @@
         <service
                 id="cmf_sonata_phpcr_admin_integration.seo.extension.metadata"
                 class="Symfony\Cmf\Bundle\SonataPhpcrAdminIntegrationBundle\Admin\Seo\Extension\SeoContentAdminExtension">
-            <argument>%cmf_sonata_phpcr_admin_integration.seo.form_group%</argument>
-            <argument>%cmf_sonata_phpcr_admin_integration.seo.form_tab%</argument>
+            <argument>%cmf_sonata_phpcr_admin_integration.seo.extension.metadata.form_group%</argument>
+            <argument>%cmf_sonata_phpcr_admin_integration.seo.extension.metadata.form_tab%</argument>
             <tag name="sonata.admin.extension" />
         </service>
     </services>

--- a/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.cs.xliff
+++ b/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.cs.xliff
@@ -491,8 +491,8 @@
                 <!-- TODO: Translate -->
                 <target>Default values</target>
             </trans-unit>
-            <trans-unit id="form.group_routes">
-                <source>form.group_routes</source>
+            <trans-unit id="form.group_routing">
+                <source>form.group_routing</source>
                 <!-- TODO: Translate -->
                 <target>Routes</target>
             </trans-unit>

--- a/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.de.xliff
+++ b/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.de.xliff
@@ -490,8 +490,8 @@
                 <source>form.group_defaults</source>
                 <target>Vorgabewerte</target>
             </trans-unit>
-            <trans-unit id="form.group_routes">
-                <source>form.group_routes</source>
+            <trans-unit id="form.group_routing">
+                <source>form.group_routing</source>
                 <target>Routen</target>
             </trans-unit>
 

--- a/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.en.xliff
+++ b/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.en.xliff
@@ -350,8 +350,8 @@
                 <source>form.group_menu_options</source>
                 <target>Menu Options</target>
             </trans-unit>
-            <trans-unit id="form.group_routes">
-                <source>form.group_routes</source>
+            <trans-unit id="form.group_routing">
+                <source>form.group_routing</source>
                 <target>Routes</target>
             </trans-unit>
 

--- a/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.es.xliff
+++ b/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.es.xliff
@@ -485,8 +485,8 @@
                 <source>form.group_defaults</source>
                 <target>Valores por defecto</target>
             </trans-unit>
-            <trans-unit id="form.group_routes">
-                <source>form.group_routes</source>
+            <trans-unit id="form.group_routing">
+                <source>form.group_routing</source>
                 <target>Rutas</target>
             </trans-unit>
 

--- a/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.fr.xliff
+++ b/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.fr.xliff
@@ -485,8 +485,8 @@
                 <source>form.group_defaults</source>
                 <target>Defauts</target>
             </trans-unit>
-            <trans-unit id="form.group_routes">
-                <source>form.group_routes</source>
+            <trans-unit id="form.group_routing">
+                <source>form.group_routing</source>
                 <target>Routes</target>
             </trans-unit>
 

--- a/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.it.xliff
+++ b/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.it.xliff
@@ -485,8 +485,8 @@
                 <source>form.group_defaults</source>
                 <target>Valori predefiniti</target>
             </trans-unit>
-            <trans-unit id="form.group_routes">
-                <source>form.group_routes</source>
+            <trans-unit id="form.group_routing">
+                <source>form.group_routing</source>
                 <target>Rotte</target>
             </trans-unit>
 

--- a/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.nl.xliff
+++ b/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.nl.xliff
@@ -483,8 +483,8 @@
                 <source>form.group_defaults</source>
                 <target>Standaardwaarden</target>
             </trans-unit>
-            <trans-unit id="form.group_routes">
-                <source>form.group_routes</source>
+            <trans-unit id="form.group_routing">
+                <source>form.group_routing</source>
                 <target>Routen</target>
             </trans-unit>
 

--- a/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.pl.xliff
+++ b/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.pl.xliff
@@ -573,8 +573,8 @@
                 <source>form.group_defaults</source>
                 <target>Domyślne</target>
             </trans-unit>
-            <trans-unit id="form.group_routes">
-                <source>form.group_routes</source>
+            <trans-unit id="form.group_routing">
+                <source>form.group_routing</source>
                 <target>Ścieżki</target>
             </trans-unit>
 

--- a/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.pt_BR.xliff
+++ b/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.pt_BR.xliff
@@ -352,8 +352,8 @@
                 <source>form.group_menu_options</source>
                 <target>opções do menu</target>
             </trans-unit>
-            <trans-unit id="form.group_routes">
-                <source>form.group_routes</source>
+            <trans-unit id="form.group_routing">
+                <source>form.group_routing</source>
                 <target>Rotas</target>
             </trans-unit>
 

--- a/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.sk.xliff
+++ b/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.sk.xliff
@@ -493,8 +493,8 @@
                 <!-- TODO: Translate -->
                 <target>Default values</target>
             </trans-unit>
-            <trans-unit id="form.group_routes">
-                <source>form.group_routes</source>
+            <trans-unit id="form.group_routing">
+                <source>form.group_routing</source>
                 <!-- TODO: Translate -->
                 <target>Routes</target>
             </trans-unit>

--- a/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.sl.xliff
+++ b/src/Resources/translations/CmfSonataPhpcrAdminIntegrationBundle.sl.xliff
@@ -485,8 +485,8 @@
                 <source>form.group_defaults</source>
                 <target>Privzete vrednosti</target>
             </trans-unit>
-            <trans-unit id="form.group_routes">
-                <source>form.group_routes</source>
+            <trans-unit id="form.group_routing">
+                <source>form.group_routing</source>
                 <target>Poti</target>
             </trans-unit>
 

--- a/tests/Resources/Fixtures/config/config.php
+++ b/tests/Resources/Fixtures/config/config.php
@@ -13,7 +13,6 @@ $container->loadFromExtension('cmf_sonata_phpcr_admin_integration', [
     'bundles' => [
         'seo' => [
             'enabled' => true,
-            'form_group' => 'seo_form',
         ],
         'core' => [
             'enabled' => true,

--- a/tests/Resources/Fixtures/config/config.xml
+++ b/tests/Resources/Fixtures/config/config.xml
@@ -5,7 +5,7 @@
 
     <config xmlns="http://cmf.symfony.com/schema/dic/sonata-phpcr-admin-integration">
         <bundles>
-            <seo enabled="true" form-group="seo_form" />
+            <seo enabled="true" />
         </bundles>
     </config>
 </container>

--- a/tests/Resources/Fixtures/config/config.yml
+++ b/tests/Resources/Fixtures/config/config.yml
@@ -2,4 +2,3 @@ cmf_sonata_phpcr_admin_integration:
     bundles:
         seo:
             enabled: true
-            form_group: seo_form

--- a/tests/Unit/DependencyInjection/CmfSonataAdminExtensionTest.php
+++ b/tests/Unit/DependencyInjection/CmfSonataAdminExtensionTest.php
@@ -128,11 +128,11 @@ class CmfSonataAdminExtensionTest extends AbstractExtensionTestCase
         ]);
 
         $this->assertContainerBuilderHasParameter(
-            'cmf_sonata_phpcr_admin_integration.core.publishable.form_group',
+            'cmf_sonata_phpcr_admin_integration.core.extension.publishable.form_group',
             'publishable_form'
         );
         $this->assertContainerBuilderHasParameter(
-            'cmf_sonata_phpcr_admin_integration.core.publish_time.form_group',
+            'cmf_sonata_phpcr_admin_integration.core.extension.publish_time.form_group',
             'publish_time_form'
         );
 

--- a/tests/Unit/DependencyInjection/CmfSonataAdminExtensionTest.php
+++ b/tests/Unit/DependencyInjection/CmfSonataAdminExtensionTest.php
@@ -62,12 +62,18 @@ class CmfSonataAdminExtensionTest extends AbstractExtensionTestCase
             'bundles' => [
                 'seo' => [
                     'enabled' => true,
-                    'form_group' => 'seo_form',
+                    'extensions' => [
+                        'metadata' => [
+                            'form_group' => 'seo_group',
+                            'form_tab' => 'seo_tab',
+                        ],
+                    ],
                 ],
             ],
         ]);
 
-        $this->assertContainerBuilderHasParameter('cmf_sonata_phpcr_admin_integration.seo.form_group', 'seo_form');
+        $this->assertContainerBuilderHasParameter('cmf_sonata_phpcr_admin_integration.seo.extension.metadata.form_group', 'seo_group');
+        $this->assertContainerBuilderHasParameter('cmf_sonata_phpcr_admin_integration.seo.extension.metadata.form_tab', 'seo_tab');
     }
 
     public function testBlockBundle()

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -44,8 +44,12 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
             'bundles' => [
                 'seo' => [
                     'enabled' => true,
-                    'form_group' => 'seo_form',
-                    'form_tab' => 'form.tab_seo',
+                    'extensions' => [
+                        'metadata' => [
+                            'form_group' => 'form.group_seo',
+                            'form_tab' => 'form.tab_seo',
+                        ],
+                    ],
                 ],
                 'core' => [
                     'enabled' => true,


### PR DESCRIPTION
fix #92 

had to do:

* [x] Moved seo extension config to `extensions.metadata`
* [x] Created configuration for route referrers admin, alligned group name with tab name
* [x] moved core parameters to `extension.` as it is for the others

Now all form group/tab configurations live under:

``` 
cmf_sonata_phpcr_admin_integration
    bundles:
         [bundle-name];
             extensions:
                [extension-name]:
                     form_group:  xxx
                     form_tab: XXX
```

and the parameters are under `cmf_sonata_phpcr_admin_integration.[bundle-name].extension.[extension-name].form_group|tab`
