### PR TITLE
Add DI tests

### DIFF
--- a/tests/Unit/DependencyInjection/CmfSonataAdminExtensionTest.php
+++ b/tests/Unit/DependencyInjection/CmfSonataAdminExtensionTest.php
@@ -45,37 +45,6 @@ class CmfSonataAdminExtensionTest extends AbstractExtensionTestCase
         $this->load([]);
     }
 
-    public function testSeoBundle()
-    {
-        $this->container->setParameter(
-            'kernel.bundles',
-            array(
-                'CmfSeoBundle' => true,
-                'CmfRoutingBundle' => true,
-                'SonataDoctrinePHPCRAdminBundle' => true,
-                'DoctrinePHPCRBundle' => true,
-                'BurgovKeyValueFormBundle' => true,
-            )
-        );
-
-        $this->load([
-            'bundles' => [
-                'seo' => [
-                    'enabled' => true,
-                    'extensions' => [
-                        'metadata' => [
-                            'form_group' => 'seo_group',
-                            'form_tab' => 'seo_tab',
-                        ],
-                    ],
-                ],
-            ],
-        ]);
-
-        $this->assertContainerBuilderHasParameter('cmf_sonata_phpcr_admin_integration.seo.extension.metadata.form_group', 'seo_group');
-        $this->assertContainerBuilderHasParameter('cmf_sonata_phpcr_admin_integration.seo.extension.metadata.form_tab', 'seo_tab');
-    }
-
     public function testBlockBundle()
     {
         $this->container->setParameter(

--- a/tests/Unit/DependencyInjection/CmfSonataAdminExtensionTest.php
+++ b/tests/Unit/DependencyInjection/CmfSonataAdminExtensionTest.php
@@ -45,32 +45,6 @@ class CmfSonataAdminExtensionTest extends AbstractExtensionTestCase
         $this->load([]);
     }
 
-    public function testBlockBundle()
-    {
-        $this->container->setParameter(
-            'kernel.bundles',
-            [
-                'CmfBlockBundle' => true,
-                'CmfMenuBundle' => true,
-                'CmfRoutingBundle' => true,
-                'SonataDoctrinePHPCRAdminBundle' => true,
-                'DoctrinePHPCRBundle' => true,
-            ]
-        );
-
-        $this->load([
-            'bundles' => [
-                'block' => [
-                    'enabled' => true,
-                    'basepath' => 'basepath_value',
-                    'menu_basepath' => 'menu_basepath_value',
-                ],
-            ],
-        ]);
-
-        $this->assertContainerBuilderHasParameter('cmf_sonata_phpcr_admin_integration.block.persistence.basepath', 'basepath_value');
-        $this->assertContainerBuilderHasParameter('cmf_sonata_phpcr_admin_integration.block.persistence.menu_basepath', 'menu_basepath_value');
-    }
 
     public function testCoreDefaults()
     {

--- a/tests/Unit/DependencyInjection/CmfSonataAdminExtensionTest.php
+++ b/tests/Unit/DependencyInjection/CmfSonataAdminExtensionTest.php
@@ -45,51 +45,6 @@ class CmfSonataAdminExtensionTest extends AbstractExtensionTestCase
         $this->load([]);
     }
 
-
-    public function testCoreDefaults()
-    {
-        $this->container->setParameter(
-            'kernel.bundles',
-            array(
-                'CmfRoutingBundle' => true,
-                'SonataDoctrinePHPCRAdminBundle' => true,
-                'DoctrinePHPCRBundle' => true,
-                'CmfCoreBundle' => true,
-            )
-        );
-
-        $this->load([
-            'bundles' => [
-                'core' => [
-                    'enabled' => true,
-                    'extensions' => [
-                        'publishable' => ['form_group' => 'publishable_form'],
-                        'publish_time' => ['form_group' => 'publish_time_form'],
-                    ],
-                ],
-            ],
-        ]);
-
-        $this->assertContainerBuilderHasParameter(
-            'cmf_sonata_phpcr_admin_integration.core.extension.publishable.form_group',
-            'publishable_form'
-        );
-        $this->assertContainerBuilderHasParameter(
-            'cmf_sonata_phpcr_admin_integration.core.extension.publish_time.form_group',
-            'publish_time_form'
-        );
-
-        $this->assertContainerBuilderHasService(
-            'cmf_sonata_phpcr_admin_integration.core.extension.publish_workflow.time_period'
-        );
-        $this->assertContainerBuilderHasService(
-            'cmf_sonata_phpcr_admin_integration.core.extension.publish_workflow.publishable'
-        );
-        $this->assertContainerBuilderHasService(
-            'cmf_sonata_phpcr_admin_integration.core.extension.child'
-        );
-    }
-
     public function testEnhancerExists()
     {
         $this->container->setParameter(

--- a/tests/Unit/DependencyInjection/CmfSonataAdminExtensionTest.php
+++ b/tests/Unit/DependencyInjection/CmfSonataAdminExtensionTest.php
@@ -33,13 +33,13 @@ class CmfSonataAdminExtensionTest extends AbstractExtensionTestCase
     {
         $this->container->setParameter(
             'kernel.bundles',
-            array(
+            [
                 'CmfSeoBundle' => true,
                 'CmfRoutingBundle' => true,
                 'SonataDoctrinePHPCRAdminBundle' => true,
                 'DoctrinePHPCRBundle' => true,
                 'BurgovKeyValueFormBundle' => true,
-            )
+            ]
         );
 
         $this->load([]);

--- a/tests/Unit/DependencyInjection/Factory/AbstractFactoryTest.php
+++ b/tests/Unit/DependencyInjection/Factory/AbstractFactoryTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2017 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SonataPhpcrAdminIntegrationBundle\Tests\Unit\DependencyInjection\Factory;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Symfony\Cmf\Bundle\SonataPhpcrAdminIntegrationBundle\DependencyInjection\CmfSonataPhpcrAdminIntegrationExtension;
+
+/**
+ * @author Maximilian Berghoff <Maximilian.Berghoff@mayflower.de>
+ */
+abstract class AbstractFactoryTest extends AbstractExtensionTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getContainerExtensions()
+    {
+        return [new CmfSonataPhpcrAdminIntegrationExtension()];
+    }
+}

--- a/tests/Unit/DependencyInjection/Factory/BlockAdminFactoryTest.php
+++ b/tests/Unit/DependencyInjection/Factory/BlockAdminFactoryTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\SonataPhpcrAdminIntegrationBundle\Tests\Unit\DependencyInjection\Factory;
+
+/**
+ * @author Maximilian Berghoff <Maximilian.Berghoff@mayflower.de>
+ */
+class BlockAdminFactoryTest extends AbstractFactoryTest
+{
+    public function testParametersBundle()
+    {
+        $this->container->setParameter(
+            'kernel.bundles',
+            [
+                'CmfBlockBundle' => true,
+                'CmfMenuBundle' => true,
+                'CmfRoutingBundle' => true,
+                'SonataDoctrinePHPCRAdminBundle' => true,
+                'DoctrinePHPCRBundle' => true,
+            ]
+        );
+
+        $this->load([
+            'bundles' => [
+                'block' => [
+                    'enabled' => true,
+                    'use_imagine' => true,
+                    'basepath' => 'basepath_value',
+                    'menu_basepath' => 'menu_basepath_value',
+                    'extensions' => [
+                        'block_cache' => [
+                           'form_group' => 'block_group',
+                            'form_tab' => 'block_tab',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasParameter('cmf_sonata_phpcr_admin_integration.block.persistence.basepath', 'basepath_value');
+        $this->assertContainerBuilderHasParameter('cmf_sonata_phpcr_admin_integration.block.persistence.menu_basepath', 'menu_basepath_value');
+        $this->assertContainerBuilderHasParameter('cmf_sonata_phpcr_admin_integration.block.extension.block_cache.form_group', 'block_group');
+        $this->assertContainerBuilderHasParameter('cmf_sonata_phpcr_admin_integration.block.extension.block_cache.form_tab', 'block_tab');
+    }
+
+    public function testAdminServicesBundle()
+    {
+        $this->container->setParameter(
+            'kernel.bundles',
+            [
+                'CmfBlockBundle' => true,
+                'CmfRoutingBundle' => true,
+                'SonataDoctrinePHPCRAdminBundle' => true,
+                'DoctrinePHPCRBundle' => true,
+            ]
+        );
+
+        $this->load([
+            'bundles' => [
+                'block' => true,
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasService('cmf_sonata_phpcr_admin_integration.block.admin_extension.cache');
+        $this->assertContainerBuilderHasService('cmf_sonata_phpcr_admin_integration.block.simple_admin');
+        $this->assertContainerBuilderHasService('cmf_sonata_phpcr_admin_integration.block.action_admin');
+        $this->assertContainerBuilderHasService('cmf_sonata_phpcr_admin_integration.block.container_admin');
+        $this->assertContainerBuilderHasService('cmf_sonata_phpcr_admin_integration.block.reference_admin');
+        $this->assertContainerBuilderHasService('cmf_sonata_phpcr_admin_integration.block.string_admin');
+    }
+
+    public function testMenuAdminServicesBundle()
+    {
+        $this->container->setParameter(
+            'kernel.bundles',
+            [
+                'CmfBlockBundle' => true,
+                'CmfMenuBundle' => true,
+                'CmfRoutingBundle' => true,
+                'SonataDoctrinePHPCRAdminBundle' => true,
+                'DoctrinePHPCRBundle' => true,
+            ]
+        );
+
+        $this->load([
+            'bundles' => [
+                'block' => [
+                    'enabled' => true,
+                    'enable_menu' => 'auto'
+                ]
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasService('cmf_sonata_phpcr_admin_integration.block.menu_admin');
+    }
+}

--- a/tests/Unit/DependencyInjection/Factory/BlockAdminFactoryTest.php
+++ b/tests/Unit/DependencyInjection/Factory/BlockAdminFactoryTest.php
@@ -24,7 +24,6 @@ class BlockAdminFactoryTest extends AbstractFactoryTest
             'bundles' => [
                 'block' => [
                     'enabled' => true,
-                    'use_imagine' => true,
                     'basepath' => 'basepath_value',
                     'menu_basepath' => 'menu_basepath_value',
                     'extensions' => [

--- a/tests/Unit/DependencyInjection/Factory/ContentAdminFactoryTest.php
+++ b/tests/Unit/DependencyInjection/Factory/ContentAdminFactoryTest.php
@@ -9,6 +9,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 /**
+ * @author Wouter de Jong <wouter@wouterj.nl>
  * @author Maximilian Berghoff <Maximilian.Berghoff@mayflower.de>
  */
 class ContentAdminFactoryTest extends \PHPUnit_Framework_TestCase

--- a/tests/Unit/DependencyInjection/Factory/ContentAdminFactoryTest.php
+++ b/tests/Unit/DependencyInjection/Factory/ContentAdminFactoryTest.php
@@ -3,6 +3,8 @@
 namespace Symfony\Cmf\Bundle\SonataPhpcrAdminIntegrationBundle\Tests\Unit\DependencyInjection\Factory;
 
 use Symfony\Cmf\Bundle\SonataPhpcrAdminIntegrationBundle\DependencyInjection\Factory\ContentAdminFactory;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 

--- a/tests/Unit/DependencyInjection/Factory/ContentAdminFactoryTest.php
+++ b/tests/Unit/DependencyInjection/Factory/ContentAdminFactoryTest.php
@@ -1,24 +1,9 @@
 <?php
 
-/*
- * This file is part of the Symfony CMF package.
- *
- * (c) 2011-2017 Symfony CMF
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Symfony\Cmf\Bundle\SonataPhpcrAdminIntegrationBundle\Tests\Unit\DependencyInjection\Factory;
 
-use Symfony\Component\Config\Definition\Builder\TreeBuilder;
-use Symfony\Component\Config\Definition\Processor;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Cmf\Bundle\SonataPhpcrAdminIntegrationBundle\DependencyInjection\Factory\ContentAdminFactory;
-
 /**
- * @author Wouter de Jong <wouter@wouterj.nl>
+ * @author Maximilian Berghoff <Maximilian.Berghoff@mayflower.de>
  */
 class ContentAdminFactoryTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Unit/DependencyInjection/Factory/ContentAdminFactoryTest.php
+++ b/tests/Unit/DependencyInjection/Factory/ContentAdminFactoryTest.php
@@ -2,6 +2,10 @@
 
 namespace Symfony\Cmf\Bundle\SonataPhpcrAdminIntegrationBundle\Tests\Unit\DependencyInjection\Factory;
 
+use Symfony\Cmf\Bundle\SonataPhpcrAdminIntegrationBundle\DependencyInjection\Factory\ContentAdminFactory;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+
 /**
  * @author Maximilian Berghoff <Maximilian.Berghoff@mayflower.de>
  */

--- a/tests/Unit/DependencyInjection/Factory/CoreAdminFactoryTest.php
+++ b/tests/Unit/DependencyInjection/Factory/CoreAdminFactoryTest.php
@@ -12,7 +12,7 @@ class CoreAdminFactoryTest extends AbstractFactoryTest
         $this->container->setParameter('kernel.bundles', [
             'CmfCoreBundle' => true,
             'SonataDoctrinePHPCRAdminBundle' => true,
-            'CmfSonataPhpcrAdminIntegrationBundle.' => true,
+            'CmfSonataPhpcrAdminIntegrationBundle' => true,
         ]);
         $this->load([
             'bundles' => [

--- a/tests/Unit/DependencyInjection/Factory/CoreAdminFactoryTest.php
+++ b/tests/Unit/DependencyInjection/Factory/CoreAdminFactoryTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\SonataPhpcrAdminIntegrationBundle\Tests\Unit\DependencyInjection\Factory;
+
+/**
+ * @author Maximilian Berghoff <Maximilian.Berghoff@mayflower.de>
+ */
+class CoreAdminFactoryTest extends AbstractFactoryTest
+{
+    public function testParametersBundle()
+    {
+        $this->container->setParameter('kernel.bundles', [
+            'CmfCoreBundle' => true,
+            'SonataDoctrinePHPCRAdminBundle' => true,
+            'CmfSonataPhpcrAdminIntegrationBundle.' => true,
+        ]);
+        $this->load([
+            'bundles' => [
+                'core' => [
+                    'enabled' => true,
+                    'extensions' => [
+                        'publishable' => ['form_group' => 'publishable_form'],
+                        'publish_time' => ['form_group' => 'publish_time_form'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasParameter(
+            'cmf_sonata_phpcr_admin_integration.core.extension.publishable.form_group',
+            'publishable_form'
+        );
+        $this->assertContainerBuilderHasParameter(
+            'cmf_sonata_phpcr_admin_integration.core.extension.publish_time.form_group',
+            'publish_time_form'
+        );
+    }
+
+    public function testAdminServicesBundle()
+    {
+
+        $this->container->setParameter(
+            'kernel.bundles',
+            [
+                'CmfRoutingBundle' => true,
+                'SonataDoctrinePHPCRAdminBundle' => true,
+                'DoctrinePHPCRBundle' => true,
+                'CmfCoreBundle' => true,
+            ]
+        );
+
+        $this->load([
+            'bundles' => [
+                'core' => true,
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasService(
+            'cmf_sonata_phpcr_admin_integration.core.extension.publish_workflow.time_period'
+        );
+        $this->assertContainerBuilderHasService(
+            'cmf_sonata_phpcr_admin_integration.core.extension.publish_workflow.publishable'
+        );
+        $this->assertContainerBuilderHasService(
+            'cmf_sonata_phpcr_admin_integration.core.extension.child'
+        );
+    }
+}

--- a/tests/Unit/DependencyInjection/Factory/MenuAdminFactoryTest.php
+++ b/tests/Unit/DependencyInjection/Factory/MenuAdminFactoryTest.php
@@ -47,7 +47,6 @@ class MenuAdminFactoryTest extends AbstractFactoryTest
             'cmf_sonata_phpcr_admin_integration.menu.extension.menu_options.advanced',
             false
         );
-
     }
 
     public function testAdminServicesBundle()

--- a/tests/Unit/DependencyInjection/Factory/MenuAdminFactoryTest.php
+++ b/tests/Unit/DependencyInjection/Factory/MenuAdminFactoryTest.php
@@ -12,7 +12,7 @@ class MenuAdminFactoryTest extends AbstractFactoryTest
         $this->container->setParameter('kernel.bundles', [
             'CmfMenuBundle' => true,
             'SonataDoctrinePHPCRAdminBundle' => true,
-            'CmfSonataPhpcrAdminIntegrationBundle.' => true,
+            'CmfSonataPhpcrAdminIntegrationBundle' => true,
         ]);
         $this->load([
             'bundles' => [

--- a/tests/Unit/DependencyInjection/Factory/MenuAdminFactoryTest.php
+++ b/tests/Unit/DependencyInjection/Factory/MenuAdminFactoryTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\SonataPhpcrAdminIntegrationBundle\Tests\Unit\DependencyInjection\Factory;
+
+/**
+ * @author Maximilian Berghoff <Maximilian.Berghoff@mayflower.de>
+ */
+class MenuAdminFactoryTest extends AbstractFactoryTest
+{
+    public function testParametersBundle()
+    {
+        $this->container->setParameter('kernel.bundles', [
+            'CmfMenuBundle' => true,
+            'SonataDoctrinePHPCRAdminBundle' => true,
+            'CmfSonataPhpcrAdminIntegrationBundle.' => true,
+        ]);
+        $this->load([
+            'bundles' => [
+                'menu' => [
+                    'enabled' => true,
+                    'extensions' => [
+                        'menu_node_referrers' => ['form_group' => 'node_referrers_form_group'],
+                        'menu_options' => ['form_group' => 'menu_options_form_group'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasParameter(
+            'cmf_sonata_phpcr_admin_integration.menu.extension.menu_node_referrers.form_group',
+            'node_referrers_form_group'
+        );
+        $this->assertContainerBuilderHasParameter(
+            'cmf_sonata_phpcr_admin_integration.menu.extension.menu_node_referrers.form_tab',
+            'form.tab_menu'
+        );
+
+        $this->assertContainerBuilderHasParameter(
+            'cmf_sonata_phpcr_admin_integration.menu.extension.menu_options.form_group',
+            'menu_options_form_group'
+        );
+        $this->assertContainerBuilderHasParameter(
+            'cmf_sonata_phpcr_admin_integration.menu.extension.menu_options.form_tab',
+            'form.tab_general'
+        );
+        $this->assertContainerBuilderHasParameter(
+            'cmf_sonata_phpcr_admin_integration.menu.extension.menu_options.advanced',
+            false
+        );
+
+    }
+
+    public function testAdminServicesBundle()
+    {
+
+        $this->container->setParameter(
+            'kernel.bundles',
+            [
+                'CmfRoutingBundle' => true,
+                'SonataDoctrinePHPCRAdminBundle' => true,
+                'DoctrinePHPCRBundle' => true,
+                'CmfMenuBundle' => true,
+            ]
+        );
+
+        $this->load([
+            'bundles' => [
+                'menu' => true,
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasService(
+            'cmf_sonata_phpcr_admin_integration.menu.extension.menu_node_referrers'
+        );
+        $this->assertContainerBuilderHasService(
+            'cmf_sonata_phpcr_admin_integration.menu.extension.menu_options'
+        );
+        $this->assertContainerBuilderHasService(
+            'cmf_sonata_phpcr_admin_integration.menu.menu_admin'
+        );
+        $this->assertContainerBuilderHasService(
+            'cmf_sonata_phpcr_admin_integration.menu.node_admin'
+        );
+    }
+}

--- a/tests/Unit/DependencyInjection/Factory/RoutingAdminFactoryTest.php
+++ b/tests/Unit/DependencyInjection/Factory/RoutingAdminFactoryTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\SonataPhpcrAdminIntegrationBundle\Tests\Unit\DependencyInjection\Factory;
+
+/**
+ * @author Maximilian Berghoff <Maximilian.Berghoff@mayflower.de>
+ */
+class RoutingAdminFactoryTest extends AbstractFactoryTest
+{
+    public function testParametersBundle()
+    {
+        $this->container->setParameter('kernel.bundles', [
+            'CmfRoutingBundle' => true,
+            'SonataDoctrinePHPCRAdminBundle' => true,
+            'CmfSonataPhpcrAdminIntegrationBundle.' => true,
+        ]);
+        $this->load([
+            'bundles' => [
+                'routing' => [
+                    'enabled' => true,
+                    'extensions' => [
+                        'referrers' => ['form_group' => 'referrers_form_group'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasParameter(
+            'cmf_sonata_phpcr_admin_integration.routing.extension.referrers.from_group',
+            'referrers_form_group'
+        );
+        $this->assertContainerBuilderHasParameter(
+            'cmf_sonata_phpcr_admin_integration.routing.extension.referrers.from_tab',
+            'form.tab_routes'
+        );
+    }
+
+    public function testAdminServicesBundle()
+    {
+
+        $this->container->setParameter(
+            'kernel.bundles',
+            [
+                'CmfRoutingBundle' => true,
+                'SonataDoctrinePHPCRAdminBundle' => true,
+                'DoctrinePHPCRBundle' => true,
+            ]
+        );
+
+        $this->load([
+            'bundles' => [
+                'routing' => true,
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasService(
+            'cmf_sonata_phpcr_admin_integration.routing.route_admin'
+        );
+        $this->assertContainerBuilderHasService(
+            'cmf_sonata_phpcr_admin_integration.routing.redirect_route_admin'
+        );
+        $this->assertContainerBuilderHasService(
+            'cmf_sonata_phpcr_admin_integration.routing.extension.route_referrers'
+        );
+        $this->assertContainerBuilderHasService(
+            'cmf_sonata_phpcr_admin_integration.routing.extension.frontend_link'
+        );
+    }
+}

--- a/tests/Unit/DependencyInjection/Factory/RoutingAdminFactoryTest.php
+++ b/tests/Unit/DependencyInjection/Factory/RoutingAdminFactoryTest.php
@@ -12,7 +12,7 @@ class RoutingAdminFactoryTest extends AbstractFactoryTest
         $this->container->setParameter('kernel.bundles', [
             'CmfRoutingBundle' => true,
             'SonataDoctrinePHPCRAdminBundle' => true,
-            'CmfSonataPhpcrAdminIntegrationBundle.' => true,
+            'CmfSonataPhpcrAdminIntegrationBundle' => true,
         ]);
         $this->load([
             'bundles' => [

--- a/tests/Unit/DependencyInjection/Factory/SeoAdminFactoryTest.php
+++ b/tests/Unit/DependencyInjection/Factory/SeoAdminFactoryTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2017 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\SonataPhpcrAdminIntegrationBundle\Tests\Unit\DependencyInjection\Factory;
+
+/**
+ * @author Maximilian Berghoff <Maximilian.Berghoff@mayflower.de>
+ */
+class SeoAdminFactoryTest extends AbstractFactoryTest
+{
+
+    public function testParametersBundle()
+    {
+        $this->container->setParameter(
+            'kernel.bundles',
+            [
+                'CmfSeoBundle' => true,
+                'CmfRoutingBundle' => true,
+                'SonataDoctrinePHPCRAdminBundle' => true,
+                'DoctrinePHPCRBundle' => true,
+                'BurgovKeyValueFormBundle' => true,
+            ]
+        );
+
+        $this->load([
+            'bundles' => [
+                'seo' => [
+                    'enabled' => true,
+                    'form_group' => 'seo_group',
+                    'form_tab' => 'seo_tab'
+                ],
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasParameter('cmf_sonata_phpcr_admin_integration.seo.form_group', 'seo_group');
+        $this->assertContainerBuilderHasParameter('cmf_sonata_phpcr_admin_integration.seo.form_tab', 'seo_tab');
+    }
+
+    public function testAdminServicesBundle()
+    {
+        $this->container->setParameter(
+            'kernel.bundles',
+            [
+                'CmfSeoBundle' => true,
+                'CmfRoutingBundle' => true,
+                'SonataDoctrinePHPCRAdminBundle' => true,
+                'DoctrinePHPCRBundle' => true,
+                'BurgovKeyValueFormBundle' => true,
+            ]
+        );
+
+        $this->load([
+            'bundles' => [
+                'seo' => true,
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasService('cmf_sonata_phpcr_admin_integration.seo.extension.metadata');
+        $this->assertContainerBuilderHasService('cmf_sonata_phpcr_admin_integration.seo.extension.metadata');
+    }
+}

--- a/tests/Unit/DependencyInjection/Factory/SeoAdminFactoryTest.php
+++ b/tests/Unit/DependencyInjection/Factory/SeoAdminFactoryTest.php
@@ -34,14 +34,18 @@ class SeoAdminFactoryTest extends AbstractFactoryTest
             'bundles' => [
                 'seo' => [
                     'enabled' => true,
-                    'form_group' => 'seo_group',
-                    'form_tab' => 'seo_tab'
+                    'extensions' => [
+                        'metadata' => [
+                            'form_group' => 'seo_group',
+                            'form_tab' => 'seo_tab',
+                        ],
+                    ],
                 ],
             ],
         ]);
 
-        $this->assertContainerBuilderHasParameter('cmf_sonata_phpcr_admin_integration.seo.form_group', 'seo_group');
-        $this->assertContainerBuilderHasParameter('cmf_sonata_phpcr_admin_integration.seo.form_tab', 'seo_tab');
+        $this->assertContainerBuilderHasParameter('cmf_sonata_phpcr_admin_integration.seo.extension.metadata.form_group', 'seo_group');
+        $this->assertContainerBuilderHasParameter('cmf_sonata_phpcr_admin_integration.seo.extension.metadata.form_tab', 'seo_tab');
     }
 
     public function testAdminServicesBundle()

--- a/tests/Unit/DependencyInjection/Factory/SeoAdminFactoryTest.php
+++ b/tests/Unit/DependencyInjection/Factory/SeoAdminFactoryTest.php
@@ -16,7 +16,6 @@ namespace Symfony\Cmf\Bundle\SonataPhpcrAdminIntegrationBundle\Tests\Unit\Depend
  */
 class SeoAdminFactoryTest extends AbstractFactoryTest
 {
-
     public function testParametersBundle()
     {
         $this->container->setParameter(


### PR DESCRIPTION
fix #38 

this PR moves the existing unit tests for DI into a bundle separated manner and creates new for non existing tests. The tests on the form_tab/group values are allway one using the default and one passing a string through the configuration.