### PR TITLE
do not report deprecations in vendors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ cache:
 env:
   matrix: SYMFONY_VERSION=4.0.*
   global:
-    - SYMFONY_DEPRECATIONS_HELPER=0
+    - SYMFONY_DEPRECATIONS_HELPER=weak_vendors
     - SYMFONY_PHPUNIT_DIR=.phpunit SYMFONY_PHPUNIT_REMOVE="symfony/yaml"
     - KERNEL_CLASS=Symfony\Cmf\Bundle\SonataPhpcrAdminIntegrationBundle\Tests\Fixtures\App\Kernel
     - SYMFONY_PHPUNIT_VERSION=5.7


### PR DESCRIPTION
this setting should limit deprecation notices to the code of this package and hide everything happening in the vendors.

refs #130