### PR TITLE
Set up github token on travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 tests/Fixtures/App/var/cache
 tests/Fixtures/App/var/logs
 !tests/Fixtures/App/var/.gitempty

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ env:
     - KERNEL_CLASS=Symfony\Cmf\Bundle\SonataPhpcrAdminIntegrationBundle\Tests\Fixtures\App\Kernel
     - SYMFONY_PHPUNIT_VERSION=5.7
     - TEST_INSTALLATION=false
+    - GITHUB_TOKEN=50f7b2dd2c8b74e441a1da1010e1a45e6c2e69f9
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ before_install:
   - phpenv config-rm xdebug.ini || true
   - composer self-update
   - if ! [ -z "$STABILITY" ]; then composer config minimum-stability ${STABILITY}; composer config prefer-stable true; fi;
+  - if [ "$GITHUB_TOKEN" != "" ]; then composer config github-oauth.github.com $GITHUB_TOKEN; fi
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require symfony/symfony:${SYMFONY_VERSION} --no-update; fi
   - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ before_install:
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require symfony/symfony:${SYMFONY_VERSION} --no-update; fi
   - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
 
-install: travis_wait composer update --prefer-dist $COMPOSER_FLAGS
+install: COMPOSER_MEMORY_LIMIT=-1 travis_wait composer update --prefer-dist $COMPOSER_FLAGS
 
 script:
   - if [ "${TEST_INSTALLATION}" == true ]; then make test_installation; else make test; fi

--- a/tests/Fixtures/App/Admin/BaseAdmin.php
+++ b/tests/Fixtures/App/Admin/BaseAdmin.php
@@ -15,6 +15,8 @@ use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\DoctrinePHPCRAdminBundle\Admin\Admin;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 /**
  * @author Maximilian Berghoff <Maximilian.Berghoff@mayflower.de>
@@ -38,9 +40,9 @@ class BaseAdmin extends Admin
     {
         $formMapper
             ->with('form.group_general')
-            ->add('name', 'text')
-            ->add('title', 'text')
-            ->add('body', 'textarea', ['required' => false])
+            ->add('name', TextType::class)
+            ->add('title', TextType::class)
+            ->add('body', TextareaType::class, ['required' => false])
             ->end()
         ;
     }

--- a/tests/Fixtures/App/Admin/MenuContentAdmin.php
+++ b/tests/Fixtures/App/Admin/MenuContentAdmin.php
@@ -14,6 +14,7 @@ namespace Symfony\Cmf\Bundle\SonataPhpcrAdminIntegrationBundle\Tests\Fixtures\Ap
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\DoctrinePHPCRAdminBundle\Admin\Admin;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 /**
  * Common base admin for Menu and MenuNode.
@@ -42,7 +43,7 @@ class MenuContentAdmin extends Admin
     {
         $formMapper
             ->with('form.group_general')
-                ->add('title', 'text')
+                ->add('title', TextType::class)
             ->end()
         ;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | `use_fos_ckeditor` (https://github.com/symfony-cmf/sonata-phpcr-admin-integration-bundle/pull/135)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | Help unblocking 129
| License       | MIT

# Objective

When a new `cvs` github repo is introduced as dependency (#135), composer on travis needs to be able to read it - this in turns require a **public read** privilege token.

This PR offer a way to set it up

# Usage

A travis env var is introduced, allowing setting up `GITHUB_TOKEN` on travis with a github token.
